### PR TITLE
Disallow prototype path override - checking magic attributes

### DIFF
--- a/__tests__/base/nx.set.test.js
+++ b/__tests__/base/nx.set.test.js
@@ -43,4 +43,11 @@ describe('nx.set name/path', () => {
     nx.set(qux, 'a.[0].b.[1]', 2);
     expect(qux).toEqual({ a: [{ b: [1, 2] }] });
   });
+
+  test.only('nx.set throw when protopath override', () => {
+    var qux = {};
+    expect(() => nx.set(qux, '__proto__.polluted', 1)).toThrow();
+    expect(() => nx.set(Object, 'prototype.polluted', 1)).toThrow();
+    expect(() => nx.set(qux, 'constructor.prototype.polluted', 2)).toThrow();
+  });
 });

--- a/src/core.js
+++ b/src/core.js
@@ -6,6 +6,12 @@
   var hasOwn = Object.prototype.hasOwnProperty;
   var INDEXES_PATH_RE = /\[(\w+)\]/g;
 
+  var disallowProtoPath = function (path, target) {
+    if (target[path] === Object.prototype) {
+      throw new Error("Unsafe path override encountered: " + path);
+    }
+  }
+
   nx.noop = function () {};
 
   nx.stubTrue = function () {
@@ -123,6 +129,7 @@
     for (var i = 0; i < len_; i++) {
       var path = paths[i];
       var target = isNaN(+paths[i + 1]) ? {} : [];
+      disallowProtoPath(path, result);
       result = result[path] = result[path] || target;
     }
     result[last] = inValue;


### PR DESCRIPTION
### 📊 Metadata *

`@jswork/next` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40jswork%2Fnext/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function throws exception, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```
// poc.js
var nx = require("@jswork/next")

var obj = {};
console.log("Before: " + {}.polluted);
nx.set(obj, "__proto__.polluted", "Yes, its polluted")
console.log("After: ", {}.polluted);
```

2. Execute the following commands in the terminal:

```
npm i @jswork/next # install vulnerable package
node poc.js # run the PoC
```

3. Check the output:

```
Before: undefined
After: Yes, its polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/107128807-b0a06300-68e6-11eb-9e03-f1e830eb91af.png)

After:
![image](https://user-images.githubusercontent.com/64132745/107128774-7df66a80-68e6-11eb-8af4-990a2799ef2e.png)

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/107128728-13452f00-68e6-11eb-920a-ca5834064bfa.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1850
